### PR TITLE
Scaling heat generation for solar collectors

### DIFF
--- a/data/coalition outfits.txt
+++ b/data/coalition outfits.txt
@@ -17,7 +17,7 @@ outfit "Small Collector Module"
 	"mass" 8
 	"outfit space" -8
 	"solar collection" .8
-	"heat generation" .4
+	"solar heat generation" .2
 	description "Solar power is the mainstay of the Coalition's merchant marine. The design of these panels has been refined over the millennia, growing ever more efficient."
 
 outfit "Large Collector Module"
@@ -29,7 +29,7 @@ outfit "Large Collector Module"
 	"mass" 28
 	"outfit space" -28
 	"solar collection" 3.3
-	"heat generation" 1.5
+	"solar heat generation" .75
 	description "One of these solar panels is enough to meet the energy needs of a medium-sized Coalition civilian ship, especially given the energy efficiency of their engines and the fact that under their laws only Heliarch ships are allowed to have weapons."
 
 outfit "Small Reactor Module"

--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -208,6 +208,9 @@ tip "shields:"
 
 tip "solar collection:"
 	`Produces a variable amount of energy depending on how far this ship is from the star at the center of the system.`
+	
+tip "solar heat generation:"
+	`Produces a variable amount of heat per second depending on how far this ship is from the star at the center of the system.`
 
 tip "max speed:"
 	`The fastest this ship can travel when using ordinary thrusters (as opposed to an afterburner).`

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -939,8 +939,8 @@ void GameData::PrintShipTable()
 		
 		double energy = attributes.Get("thrusting energy")
 			+ attributes.Get("turning energy");
-		double heat = attributes.Get("heat generation") - attributes.Get("cooling")
-			+ attributes.Get("thrusting heat") + attributes.Get("turning heat");
+		double heat = attributes.Get("heat generation") + attributes.Get("solar heat generation")
+			- attributes.Get("cooling") + attributes.Get("thrusting heat") + attributes.Get("turning heat");
 		for(const auto &oit : ship.Outfits())
 			if(oit.first->IsWeapon() && oit.first->Reload())
 			{

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -47,6 +47,7 @@ namespace {
 		"shield energy",
 		"shield heat",
 		"solar collection",
+		"solar heat generation",
 		"thrusting energy",
 		"thrusting heat",
 		"turn",

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -769,6 +769,7 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		energy -= ionization;
 		energy = max(0., energy);
 		heat += attributes.Get("heat generation");
+		heat += scale * attributes.Get("solar heat generation");
 		heat -= coolingEfficiency * attributes.Get("cooling");
 		heat = max(0., heat);
 		
@@ -1978,7 +1979,9 @@ double Ship::IdleHeat() const
 	// heat = heat * diss + heatGen - cool - activeCool * heat / (100 * mass)
 	// heat = heat * (diss - activeCool / (100 * mass)) + (heatGen - cool)
 	// heat * (1 - diss + activeCool / (100 * mass)) = (heatGen - cool)
-	double production = max(0., attributes.Get("heat generation") - cooling);
+	double scale = .2 + 1.8 / (.001 * position.Length() + 1);
+	double production = max(0., attributes.Get("heat generation") 
+							+ scale * attributes.Get("solar heat generation") - cooling);
 	double dissipation = .001 * attributes.Get("heat dissipation") + activeCooling / (100. * Mass());
 	return production / dissipation;
 }

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -266,7 +266,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const Depreciation &dep
 			- attributes.Get("cooling energy"))));
 	double efficiency = ship.CoolingEfficiency();
 	heatTable.push_back(Format::Number(
-		60. * (attributes.Get("heat generation")
+		60. * (attributes.Get("heat generation") + attributes.Get("solar heat generation")
 			- efficiency * (attributes.Get("cooling") + attributes.Get("active cooling")))));
 	attributesHeight += 20;
 	tableLabels.push_back("moving:");


### PR DESCRIPTION
Solar collectors generate up to the maximum heat value given in
Outfitting when close to a star, and drop down to a tenth of this value
as the energy generated drops proportionately.