### PR TITLE
Turret firing arc

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -344,6 +344,9 @@ tip "slowing damage / second:"
 tip "disruption damage / second:"
 	`Disrupts the target's shields, allowing weapon damage to "leak through" to the hull even if shields are up. Shield disruption wears off over time.`
 
+tip "firing arc:"
+	`The full angle through which a weapon can swivel/traverse. By default every turret has a 360 degree firing arc.`	
+
 tip "firing energy / second:"
 	`Energy consumed by this weapon per second when firing.`
 

--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -167,6 +167,18 @@ Point Angle::Rotate(const Point &point) const
 
 
 
+// Return the shortest distance between two angles in degrees.
+double Angle::Distance(const Angle &compare) const
+{
+	double distance = (angle - compare.angle) / DEG_TO_STEP;
+
+	// Map the distance inside the range (-180,180].
+	distance -= 360 * ((int) distance / 180);
+	return distance;
+}
+
+
+
 // Constructor using Angle's internal representation.
 Angle::Angle(int32_t angle)
 	: angle(angle)

--- a/source/Angle.h
+++ b/source/Angle.h
@@ -54,6 +54,9 @@ public:
 	// Return a point rotated by this angle around (0, 0).
 	Point Rotate(const Point &point) const;
 	
+	// Return the shortest distance between two angles in degrees.
+	double Distance(const Angle &compare) const;
+
 	
 private:
 	explicit Angle(int32_t angle);

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -280,9 +280,20 @@ void Body::AddFrameRate(double framesPerSecond)
 
 
 
+void Body::PauseAnimation()
+{
+	++pause;
+}
+
+
+
 // Set the current time step.
 void Body::SetStep(int step, bool isHighDPI) const
 {
+	// If the animation is paused, reduce the step by however many frames it has
+	// been paused for.
+	step -= pause;
+	
 	// If the step is negative or there is no sprite, do nothing. This updates
 	// and caches the mask and the frame so that if further queries are made at
 	// this same time step, we don't need to redo the calculations.

--- a/source/Body.h
+++ b/source/Body.h
@@ -88,6 +88,7 @@ protected:
 	// Adjust the frame rate.
 	void SetFrameRate(double framesPerSecond);
 	void AddFrameRate(double framesPerSecond);
+	void PauseAnimation();
 	
 	
 protected:
@@ -123,6 +124,7 @@ private:
 	mutable bool randomize = false;
 	bool repeat = true;
 	bool rewind = false;
+	int pause = 0;
 	
 	// Frame info for the current step:
 	mutable int currentStep = -1;

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -47,6 +47,7 @@ public:
 	bool IsHoming() const;
 	bool IsAntiMissile() const;
 	bool CanAim() const;
+	double FiringArc() const;
 	
 	// Check if this weapon is ready to fire.
 	bool IsReady() const;
@@ -86,6 +87,7 @@ private:
 	Angle angle;
 	// Reload timers and other attributes.
 	double reload = 0.;
+	double firingArc = 0.;
 	double burstReload = 0.;
 	int burstCount = 0;
 	bool isTurret = false;

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -338,6 +338,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"firing energy / shot:",
 		"firing heat / shot:",
 		"firing fuel / shot:",
+		"firing arc:",
 		"inaccuracy:",
 		"blast radius:",
 		"missile strength:",
@@ -353,6 +354,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		outfit.FiringEnergy(),
 		outfit.FiringHeat(),
 		outfit.FiringFuel(),
+		// For outfitting display, convert back to showing the full firing arc.
+		outfit.FiringArc() * 2.,
 		outfit.Inaccuracy(),
 		outfit.BlastRadius(),
 		static_cast<double>(outfit.MissileStrength()),

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -753,7 +753,9 @@ bool Ship::Move(list<Effect> &effects, list<shared_ptr<Flotsam>> &flotsam)
 		outfitScan = max(0., outfitScan - 1.);
 	
 	// Update ship supply levels.
-	if(!isDisabled)
+	if(isDisabled)
+		PauseAnimation();
+	else
 	{
 		// Ramscoops work much better when close to the system center. Even if a
 		// ship has no ramscoop, it can harvest a tiny bit of fuel by flying

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -108,6 +108,9 @@ void Weapon::LoadWeapon(const DataNode &node)
 				inaccuracy = value;
 			else if(key == "turret turn")
 				turretTurn = value;
+			else if(key == "firing arc")
+				// It's easier to work with the angle we can swivel either side.
+				firingArc = value * .5;
 			else if(key == "tracking")
 				tracking = max(0., min(1., value));
 			else if(key == "optical tracking")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -74,6 +74,7 @@ public:
 	double Turn() const;
 	double Inaccuracy() const;
 	double TurretTurn() const;
+	double FiringArc() const;
 	
 	double Tracking() const;
 	double OpticalTracking() const;
@@ -154,6 +155,7 @@ private:
 	double turn = 0.;
 	double inaccuracy = 0.;
 	double turretTurn = 0.;
+	double firingArc = 0;
 	
 	double tracking = 0.;
 	double opticalTracking = 0.;
@@ -208,6 +210,7 @@ inline double Weapon::HardpointOffset() const { return hardpointOffset; }
 inline double Weapon::Turn() const { return turn; }
 inline double Weapon::Inaccuracy() const { return inaccuracy; }
 inline double Weapon::TurretTurn() const { return turretTurn; }
+inline double Weapon::FiringArc() const { return firingArc; }
 
 inline double Weapon::Tracking() const { return tracking; }
 inline double Weapon::OpticalTracking() const { return opticalTracking; }


### PR DESCRIPTION
Weapons can optionally have the weapon attribute "firing arc" with a
number between 0 and 180, and can swivel that many degrees left or right
of forward. This can allow for swivel cannons (can set up using a gun
mount as normal, and choose a "firing arc" that's fairly low) or for turrets
with a blind spot at the back. By default, anything taking a turret mount
will swivel the full 180, as before.

Missile boat AI will trigger somewhere between 1000 and 2000 range
depending on the swivel angle: as before, fixed guns at 2000 and normal
turrets at 1000, but e.g. a 90° swivel turret will trigger missile boat
AI at 1500 range.

This can also be used on anti-missile weapons. Lastly, if you try to fire
while outside of the firing arc, the gun will try to far as far toward the
target as it can: in practice, this is more playable than not firing at all,
or reverting to fire straight forward.

**Context:** though this is generally useful, I wrote it for my [Trin](https://github.com/Elyssaen/trin) [Mobulas](https://github.com/Elyssaen/trin/issues/1). They're stocky battlecruisers which rely on fixed firepower, and have serious convergence problems if they use normal fixed guns. I wanted to create some swivel cannons for them modelled on Escape Velocity Override's swivel phase cannons (used by Azdaras) and EV Nova's Fusion Pulse Batteries.

**Notes:** this _isn't_ about limiting the turning rate of a turret, though it's compatible with such a feature. Also, the 'forward' point of any weapon is always _forward_, so this doesn't allow for broadsides and rear weapons. That'd be a great enhancement, but would require additional AI work. (Note that by 'forward' I mean the ship's facing + the convergence angle.)